### PR TITLE
Added Bower configuration.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "paymentfont",
+  "description": "A sleek SVG webfont for payment operators and methods.",
+  "version": "0.2.0",
+  "keywords": [],
+  "homepage": "http://paymentfont.io",
+  "dependencies": {},
+  "devDependencies": {},
+  "license": ["OFL-1.1", "MIT"],
+  "main": [
+    "./css/*",
+    "./fonts/*"
+  ],
+  "ignore": [
+    "*/.*",
+    "*.png",
+    "*.md"
+  ]
+}


### PR DESCRIPTION
Would be awesome if you would merge this so that people can use your font with their favourite build tools.

After that it would be nice if you'd register it with bower.io:

http://bower.io/docs/creating-packages/#register

I just checked.... "paymentfont" and "paymentfont.io" are still available.

BTW: thanks for the awesome work... 
