### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Originally made for our [WooCommerce Payment Methods](https://wordpress.org/plug
 
 **Get started at [PaymentFont.io](http://paymentfont.io)!**
 
-##Usage/Example
+## Usage/Example
 
 ```html
 <i class="pf pf-paypal"></i> PayPal
@@ -19,7 +19,7 @@ You can view all classes in the [Preview Image](https://github.com/vendocrat/Pay
 
 ![PaymentFont Preview](https://github.com/vendocrat/PaymentFont/blob/master/preview.png)
 
-##Included Icons
+## Included Icons
 Here's an incomplete list of the included icons:
 
 * Amazon
@@ -91,10 +91,10 @@ Here's an incomplete list of the included icons:
 * Western Union
 * Wirecard
 
-##Installation
+## Installation
 To be added, feel welcome to contribute an installation guide ;)
 
-##Changelog
+## Changelog
 - 2014-09-22 v0.1.0 Initial release. (74 icons)
 - 2014-10-29 v0.1.1 Minor fixes and improvements, added demo site [PaymentFont.io](http://paymentfont.io).
 - 2014-10-30 v0.1.2 Added "copy to clipboard" functionality to demo site.
@@ -105,7 +105,7 @@ To be added, feel welcome to contribute an installation guide ;)
 - 2015-04-24 v1.1.1 Quick fix for icon vertical offset, added package.json.
 - 2015-04-26 v1.1.2 Fixed a typo in CSS class for Great British Pound (pf-gpb is now pf-gbp).
 
-##License
+## License
 - The font is licensed under the SIL OFL 1.1:
   - http://scripts.sil.org/OFL
 - The CSS files are licensed under the MIT License:
@@ -113,11 +113,11 @@ To be added, feel welcome to contribute an installation guide ;)
 - Attribution is not required, but much appreciated:
   - PaymentFont by vendocrat - http://paymentfont.io
 
-##Disclaimer
+## Disclaimer
 All used trademarks, brands and/or names are the property of their respective owners.
 The use of these trademarks, brands and/or names does not indicate endorsement of the property holder by us, nor vice versa.
 
-##Author
+## Author
 **Handcrafted with love by [vendocrat](https://vendocr.at/) in Vienna &amp; Rome.**
 
 Follow us on [Twitter](https://twitter.com/vendocrat), like us on [Facebook](https://www.facebook.com/vendocrat), circle us on [Google+](https://plus.google.com/+vendocrat) or fork us on [GitHub](https://github.com/vendocrat)!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
